### PR TITLE
43: configure using DOCKER_HOST et al. (logic from docker-compose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ $ PYTHONPATH="$PWD:$PYTHONPATH" ./sen/cli.py
 
 # Prerequisite
 
-Bear in mind that unix socket for docker engine needs to be accessible. By default it's located at `/run/docker.sock`.
+Either:
+
+* The unix socket for docker engine needs to be accessible. By default it's located at `/run/docker.sock`.
+
+OR
+
+* Have the `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` set properly.  If you're using `docker-machine` or `boot2docker` you're all set!
 
 
 # Keybindings

--- a/sen/docker_backend.py
+++ b/sen/docker_backend.py
@@ -410,7 +410,8 @@ class DockerBackend:
     @property
     def client(self):
         if self._client is None:
-            self._client = docker.AutoVersionClient()
+            kwargs = docker.utils.kwargs_from_env(assert_hostname=False)
+            self._client = docker.AutoVersionClient(**kwargs)
         return self._client
 
     # backend queries


### PR DESCRIPTION
should fix #43

e.g. I use docker-machine, its set these environment vars:
```
DOCKER_HOST=tcp://192.168.99.100:2376
DOCKER_MACHINE_NAME=docker-vm
DOCKER_TLS_VERIFY=1
DOCKER_CERT_PATH=/Users/rheflin/.docker/machine/machines/docker-vm
```
These changes allow your tool to connect to the non-local docker instance running w/in the VM docker-machine setup!