### PR TITLE
Slimmer image based on Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM fedora:22
+FROM alpine:3.2
 MAINTAINER Tomas Tomecek <ttomecek@redhat.com> @TomasTomec
 
-RUN dnf install -y python3-pip git python3-urwid python3-docker-py python3-humanize
-
-RUN mkdir /home/sen
-WORKDIR /home/sen
 COPY . /home/sen
 
-RUN pip3 install .
+RUN apk -U add python3 \
+	&& apk add -t build python3-dev libc-dev gcc \
+	&& pip3 install /home/sen \
+	&& apk del --purge build \
+	&& rm /var/cache/apk/*
+
+ENV DOCKER_HOST http+unix://run/docker.sock
 
 ENTRYPOINT ["sen"]


### PR DESCRIPTION
The idea of a significantly slimmer image based on Alpine Linux. Reduces resulting size by up to 400 MB.

```console
$ d images | grep sen
sen                  slim                ec46dd068081        29 seconds ago      57.67 MB
sen                  original            b257e3fe31ee        45 minutes ago      457.8 MB
```

The one larger difference here is that we install requirements from pip instead of system packages. The Fedora packages for some things (such as the Docker client) were older at version 1.1.0. The latest pip installed package is 1.5.0. If this is undesirable then the package version should probably be pinned in `requirements.txt` (though, it does seem to work fine on 1.5.0).