### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+- amd64
+- ppc64le
 python:
 - '3.5'
 - '3.6'


### PR DESCRIPTION
This PR adds CI support to linux on power little endian architecture. "sen" is part of ubuntu distribution on this architecture as well. Continuously building/testing on this along with intel will ensure we detect/fix issues if any in the early and we are always up-to-date.