### PR TITLE
rpm: move %generate_buildrequires after %prep

### DIFF
--- a/sen.spec
+++ b/sen.spec
@@ -7,7 +7,7 @@
 
 
 Name:           %{srcname}
-Version:        0.9.0-dev
+Version:        0.9.0
 Release:        %autorelease
 Summary:        %{sum}
 


### PR DESCRIPTION
so it's aligned with Fedora Rawhide